### PR TITLE
Fix worksheet spec generation using OpenAI chat API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# AI Assistant Companion
+
+This Flask application generates AI-powered worksheets. It was initially designed to run on Replit and stores worksheet metadata in Postgres.
+
+## Environment Variables
+
+Create a `.env` file with the following variables:
+
+- `OPENAI_API_KEY`: API key for OpenAI models.
+- `SESSION_SECRET`: secret key for Flask sessions.
+- `DATABASE_URL`: PostgreSQL connection string (from Supabase or other host).
+- `GOOGLE_OAUTH_CLIENT_ID`: Google OAuth client ID.
+- `GOOGLE_OAUTH_CLIENT_SECRET`: Google OAuth client secret.
+- `REPLIT_DEV_DOMAIN` (optional): Dev domain for callback URL when running locally.
+
+If you integrate Pinecone, also add:
+
+- `PINECONE_API_KEY`: Pinecone API key.
+- `PINECONE_ENV`: Pinecone environment region name.
+
+## Removing Replit Specifics
+
+- Delete `.replit` config and remove CSS references to `cdn.replit.com` in templates.
+- Replace the Replit Postgres connection with your own database or Supabase.
+- Update OAuth redirect URLs to your domain.
+- Remove references to `REPLIT_DEV_DOMAIN` once deployed elsewhere.
+
+## Supabase and Pinecone
+
+To migrate, connect SQLAlchemy to the Supabase Postgres URL and configure Pinecone to store embeddings instead of the Postgres `embedding` array. Use Supabase Auth or Google OAuth for authentication.

--- a/llm_client.py
+++ b/llm_client.py
@@ -52,15 +52,14 @@ Return a JSON object with this exact structure:
 
 Keep layout within 612x792 points (letter size). Include 5-10 educational elements."""
 
-        response = openai_client.chat.completions.create(
+        response = openai_client.responses.create(
             model="gpt-4.1",
-            messages=[{"role": "user", "content": prompt}]
+            input=prompt
         )
-
+        
         # Parse the JSON from the response
         import re
-        content = response.choices[0].message.content
-        json_match = re.search(r'\{.*\}', content, re.DOTALL)
+        json_match = re.search(r'\{.*\}', response.output_text, re.DOTALL)
         if json_match:
             return json.loads(json_match.group())
         else:

--- a/llm_client.py
+++ b/llm_client.py
@@ -52,14 +52,15 @@ Return a JSON object with this exact structure:
 
 Keep layout within 612x792 points (letter size). Include 5-10 educational elements."""
 
-        response = openai_client.responses.create(
+        response = openai_client.chat.completions.create(
             model="gpt-4.1",
-            input=prompt
+            messages=[{"role": "user", "content": prompt}]
         )
-        
+
         # Parse the JSON from the response
         import re
-        json_match = re.search(r'\{.*\}', response.output_text, re.DOTALL)
+        content = response.choices[0].message.content
+        json_match = re.search(r'\{.*\}', content, re.DOTALL)
         if json_match:
             return json.loads(json_match.group())
         else:


### PR DESCRIPTION
## Summary
- fix `generate_worksheet_spec` to use `chat.completions.create`
- parse the returned chat message correctly

## Testing
- `python -m py_compile llm_client.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_683f79bd305c832488e197a3acea2048